### PR TITLE
Sort missing parameters in the failure message

### DIFF
--- a/lib/Params/Validate/PP.pm
+++ b/lib/Params/Validate/PP.pm
@@ -347,7 +347,7 @@ OUTER:
     if (@missing) {
         my $called = _get_called();
 
-        my $missing = join ', ', map {"'$_'"} @missing;
+        my $missing = join ', ', map {"'$_'"} sort @missing;
         $options->{on_fail}->( "Mandatory parameter"
                 . ( @missing > 1 ? 's' : '' )
                 . " $missing missing in call to $called\n" );

--- a/lib/Params/Validate/XS.xs
+++ b/lib/Params/Validate/XS.xs
@@ -1326,6 +1326,7 @@ validate(HV* p, HV* specs, HV* options, HV* ret) {
     apply_defaults(ret, p, specs, missing);
 
     if (av_len(missing) > -1) {
+        sortsv(AvARRAY(missing), 1 + av_len(missing), Perl_sv_cmp);
         SV* buffer = newSVpv("Mandatory parameter", 0);
         SV *caller = get_caller(options);
 

--- a/t/lib/PVTests/Standard.pm
+++ b/t/lib/PVTests/Standard.pm
@@ -65,6 +65,13 @@ my @Tests = (
         expect => q{},
     },
 
+    # sort missing params
+    {
+        sub    => 'sub3',
+        p      => [],
+        expect => qr|^Mandatory parameters 'bar', 'baz', 'brax', 'foo', 'quux' missing|,
+    },
+
     # simple types
     {
         sub => 'sub3',


### PR DESCRIPTION
to get consistent output each time. Fixes 115241.