### PR TITLE
use native --pureperl_only functionality in Module::Build > 0.4227

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 {{$NEXT}}
 
+- Supports pure Perl builds via the standard incantation of "perl Build.PL --pureperl_only".
+  The "--pp" flag is still supported.
+
 1.29    2017-06-11
 
 - Fixes for MSVC compilation. Patch by Andy Grundman. PR #15.

--- a/inc/MyMBClass.pm
+++ b/inc/MyMBClass.pm
@@ -12,7 +12,6 @@ sub new {
     my $self = $class->SUPER::new( @_ );
 
     if ( defined ( my $pp = $self->args( 'pp' ) ) ) {
-        $self->args( 'pureperl_only', $pp );
         $self->pureperl_only($pp);
     }
 

--- a/inc/MyMBClass.pm
+++ b/inc/MyMBClass.pm
@@ -1,0 +1,23 @@
+package MyMBClass;
+
+use strict;
+use warnings;
+
+use parent 'Module::Build';
+
+sub new {
+
+    my  $class = shift;
+
+    my $self = $class->SUPER::new( @_ );
+
+    if ( defined ( my $pp = $self->args( 'pp' ) ) ) {
+        $self->args( 'pureperl_only', $pp );
+        $self->pureperl_only($pp);
+    }
+
+    return $self;
+}
+
+1;
+

--- a/inc/MyModuleBuild.pm
+++ b/inc/MyModuleBuild.pm
@@ -5,13 +5,24 @@ use warnings;
 
 use Moose;
 
-extends 'Dist::Zilla::Plugin::ModuleBuild::XSOrPP';
+extends 'Dist::Zilla::Plugin::ModuleBuild';
+
+has '+mb_version' => (
+  default => 0.4227,
+);
+
+has '+mb_class' => (
+  default => 'MyMBClass'
+);
 
 around module_build_args => sub {
     my $orig = shift;
     my $self = shift;
 
     my $args = $self->$orig(@_);
+
+    $args->{allow_pureperl} = 1;
+    $args->{get_options} = { pp => { } };
 
     $args->{c_source} = 'c';
     if ( $ENV{TRAVIS} ) {


### PR DESCRIPTION
`Module::Build` v0.4227 supports a `--pureperl_only` flag.  This commit switches to that from Dist::Zilla::Plugin::ModuleBuild::XSOrPP.  The previous `--pp` flag is still accepted.

