### PR TITLE
Require newer ppport.h version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,6 +31,7 @@ stopwords = onwards
 stopwords = pre
 stopwords = runtime
 PPPort.filename = c/ppport.h
+PPPort.version = 3.68
 -remove = Test::CleanNamespaces
 -remove = Test::TidyAll
 -remove = Test::Version


### PR DESCRIPTION
Update the required PPPort version to fix compatibility with perls <= 5.8.5.